### PR TITLE
fix: make interactive menus reliable across platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,5 +38,5 @@
 - Ensure `make lint`, `make test`, and `make check` pass; avoid reducing coverage.
 
 ## Configuration Tips
-- Optional dependency: `keypress` enables richer keyboard handling; keep fallbacks intact.
+- Required dependencies: `cli` and `keypress`; keep the numbered-prompt fallbacks intact for environments without single-key or ANSI support.
 - Avoid adding heavyweight dependencies without maintainers’ approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The package enables R users to create intuitive, keyboard-navigable menus for se
 - **Pre-selection support** - Start with items already selected
 - **Return flexibility** - Return values or indices
 - **Non-interactive fallback** - Works in batch mode with sensible defaults
-- **Minimal dependencies** - Only requires `cli` package
+- **Minimal dependencies** - Only requires the `cli` and `keypress` packages
 
 ## Package Structure
 
@@ -28,8 +28,7 @@ climenu/
 │   ├── menu.R             # Main menu interface
 │   ├── select.R           # Single selection implementation
 │   ├── checkbox.R         # Multiple selection implementation
-│   ├── utils.R            # Shared utilities
-│   └── zzz.R             # Package environment setup
+│   └── utils.R            # Shared utilities
 ├── tests/testthat/        # Test suite
 ├── vignettes/             # Long-form documentation
 ├── man/                   # Documentation (auto-generated)
@@ -98,10 +97,10 @@ R -e "devtools::install()"
 ## Key Dependencies
 
 ### Required
-- `cli` (>= 3.6.0) - For styled terminal output
+- `cli` (>= 3.6.0) - For styled terminal output and capability detection
+- `keypress` (>= 1.0.0) - For true single-keypress capture
 
 ### Suggested
-- `keypress` - For true single-keypress capture (highly recommended for best UX)
 - `testthat` (>= 3.0.0) - For testing
 - `roxygen2` (>= 7.0.0) - For documentation
 - `devtools` - For development workflow
@@ -114,10 +113,10 @@ R -e "devtools::install()"
 
 The package uses two modes for keyboard input:
 
-1. **keypress mode** (best experience) - When the `keypress` package is available, arrow keys and single keypresses work natively
-2. **readline mode** (fallback) - When `keypress` is not available, users type commands and press Enter
+1. **keypress mode** (best experience) - When the terminal supports single-key capture (`keypress::has_keypress_support()`) and ANSI escapes, arrow keys and single keypresses work natively
+2. **numbered-prompt mode** (fallback) - Otherwise (e.g. RStudio console, RGui, non-ANSI terminals), users type numbered commands and press Enter
 
-The `get_keypress()` function in `R/utils.R` handles this detection and fallback automatically.
+`keypress_supported()` and `ansi_supported()` in `R/utils.R` handle this detection; `select()`/`checkbox()` route to the `*_fallback()` functions when either check fails. Note that `keypress::keypress()` returns special keys as named strings ("up", "enter", "escape", ...) — `get_keypress()` maps them to menu actions.
 
 ### Terminal Control
 
@@ -125,7 +124,7 @@ The package uses ANSI escape sequences for terminal manipulation:
 - `\033[<n>A` - Move cursor up n lines
 - `\033[2K` - Clear current line
 
-These sequences work in most modern terminals (macOS Terminal, iTerm2, Linux terminals, Windows Terminal, VSCode terminal).
+These sequences work in most modern terminals (macOS Terminal, iTerm2, Linux terminals, Windows Terminal, VSCode terminal). The live-menu path is only used when `cli::num_ansi_colors() > 1` indicates ANSI support; rendered lines are truncated to the console width so the redraw never miscounts wrapped rows, and Unicode glyphs degrade to ASCII on non-UTF-8 terminals (`cli::is_utf8_output()`).
 
 ### Menu Rendering
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,5 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Config/testthat/parallel: TRUE
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3

--- a/R/checkbox.R
+++ b/R/checkbox.R
@@ -50,6 +50,7 @@ checkbox <- function(choices,
                      allow_select_all = FALSE) {
   # Validate inputs
   validate_choices(choices)
+  validate_max_visible(max_visible)
   if (!is.logical(allow_select_all) || length(allow_select_all) != 1 || is.na(allow_select_all)) {
     cli::cli_abort("allow_select_all must be a single logical value")
   }
@@ -77,8 +78,9 @@ checkbox <- function(choices,
     }
   }
 
-  # Fallback for terminals without single-key support (e.g. RStudio/RGui on Windows)
-  if (!keypress_supported()) {
+  # Fallback for terminals without single-key support (e.g. RStudio/RGui on
+  # Windows) or without ANSI escape support (needed to redraw the menu)
+  if (!keypress_supported() || !ansi_supported()) {
     return(checkbox_fallback(choices, prompt, selected_indices, return_index, allow_select_all))
   }
 
@@ -129,8 +131,8 @@ checkbox <- function(choices,
     # Clear previous menu
     clear_lines(n_lines)
 
-    # Handle key press
-    if (key %in% c("up", "k")) {
+    # Handle key press (j/k are already mapped to up/down in get_keypress)
+    if (key == "up") {
       cursor_pos <- if (cursor_pos > 1) cursor_pos - 1L else effective_length
 
       # Adjust window if cursor moved outside visible range
@@ -143,7 +145,7 @@ checkbox <- function(choices,
           window_offset <- max(1L, effective_length - max_visible + 1L)
         }
       }
-    } else if (key %in% c("down", "j")) {
+    } else if (key == "down") {
       cursor_pos <- if (cursor_pos < effective_length) cursor_pos + 1L else 1L
 
       # Adjust window if cursor moved outside visible range

--- a/R/menu.R
+++ b/R/menu.R
@@ -8,6 +8,11 @@
 #' @param type Menu type: "select" (single) or "checkbox" (multiple) (default: "select")
 #' @param selected Pre-selected items (indices or values)
 #' @param return_index Return indices instead of values (default: FALSE)
+#' @param max_visible Maximum number of items to display at once (default: 10).
+#'   Set to NULL to show all items.
+#' @param allow_select_all If `TRUE`, adds a "Select all" / "Deselect all"
+#'   option at the top of the menu. Only used when `type = "checkbox"`
+#'   (default: FALSE).
 #'
 #' @return Selected item(s) as character vector or indices, or NULL if cancelled
 #' @export
@@ -28,7 +33,9 @@ menu <- function(choices,
                  prompt = "Select an item:",
                  type = c("select", "checkbox"),
                  selected = NULL,
-                 return_index = FALSE) {
+                 return_index = FALSE,
+                 max_visible = 10L,
+                 allow_select_all = FALSE) {
   type <- match.arg(type)
 
   if (type == "checkbox") {
@@ -36,14 +43,17 @@ menu <- function(choices,
       choices = choices,
       prompt = prompt,
       selected = selected,
-      return_index = return_index
+      return_index = return_index,
+      max_visible = max_visible,
+      allow_select_all = allow_select_all
     ))
   } else {
     return(select(
       choices = choices,
       prompt = prompt,
       selected = selected,
-      return_index = return_index
+      return_index = return_index,
+      max_visible = max_visible
     ))
   }
 }

--- a/R/select.R
+++ b/R/select.R
@@ -28,6 +28,7 @@ select <- function(choices,
                    max_visible = 10L) {
   # Validate inputs
   validate_choices(choices)
+  validate_max_visible(max_visible)
 
   # Determine initial cursor position
   cursor_pos <- normalize_selected(selected, choices, multiple = FALSE)
@@ -37,12 +38,13 @@ select <- function(choices,
 
   # Check if running in interactive mode
   if (!interactive()) {
-    cli::cli_warn("Not running in interactive mode. Returning first choice.")
-    return(if (return_index) 1L else choices[1])
+    cli::cli_warn("Not running in interactive mode. Returning the default choice.")
+    return(if (return_index) cursor_pos else choices[cursor_pos])
   }
 
-  # Fallback for terminals without single-key support (e.g. RStudio/RGui on Windows)
-  if (!keypress_supported()) {
+  # Fallback for terminals without single-key support (e.g. RStudio/RGui on
+  # Windows) or without ANSI escape support (needed to redraw the menu)
+  if (!keypress_supported() || !ansi_supported()) {
     return(select_fallback(choices, prompt, cursor_pos, return_index))
   }
 
@@ -81,8 +83,8 @@ select <- function(choices,
     # Clear previous menu
     clear_lines(n_lines)
 
-    # Handle key press
-    if (key %in% c("up", "k")) {
+    # Handle key press (j/k are already mapped to up/down in get_keypress)
+    if (key == "up") {
       cursor_pos <- if (cursor_pos > 1) cursor_pos - 1L else n_choices
 
       # Adjust window if cursor moved outside visible range
@@ -95,7 +97,7 @@ select <- function(choices,
           window_offset <- max(1L, n_choices - max_visible + 1L)
         }
       }
-    } else if (key %in% c("down", "j")) {
+    } else if (key == "down") {
       cursor_pos <- if (cursor_pos < n_choices) cursor_pos + 1L else 1L
 
       # Adjust window if cursor moved outside visible range

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,6 +17,17 @@ keypress_supported <- function() {
   )
 }
 
+#' Check whether the current terminal understands ANSI escape sequences
+#'
+#' Keypress support and ANSI support are independent: legacy Windows
+#' consoles can read single keys yet print escape sequences literally.
+#' Color support implies working VT processing, so use cli's detection.
+#' @keywords internal
+#' @noRd
+ansi_supported <- function() {
+  isTRUE(cli::num_ansi_colors() > 1L)
+}
+
 #' Emit a one-time info message explaining the fallback
 #' @keywords internal
 #' @noRd
@@ -25,7 +36,7 @@ notify_fallback_once <- function() {
     return(invisible())
   }
   cli::cli_alert_info(
-    "Your terminal does not support single-key input (e.g. RStudio or RGui on Windows). Using numbered-prompt mode."
+    "Your terminal does not support live menus (single-key input and ANSI escapes, e.g. RStudio or RGui on Windows). Using numbered-prompt mode."
   )
   climenu_env$fallback_notice_shown <- TRUE
   invisible()
@@ -44,6 +55,20 @@ validate_choices <- function(choices) {
   if (any(is.na(choices))) {
     cli::cli_abort("choices must not contain NA values")
   }
+}
+
+#' Validate max_visible parameter
+#' @keywords internal
+#' @noRd
+validate_max_visible <- function(max_visible) {
+  if (is.null(max_visible)) {
+    return(invisible())
+  }
+  if (!is.numeric(max_visible) || length(max_visible) != 1 ||
+        is.na(max_visible) || max_visible < 1) {
+    cli::cli_abort("max_visible must be NULL or a single number >= 1")
+  }
+  invisible()
 }
 
 #' Normalize selected parameter to indices
@@ -78,6 +103,29 @@ normalize_selected <- function(selected, choices, multiple = FALSE) {
   return(indices)
 }
 
+#' Menu glyphs, with ASCII fallbacks for non-UTF-8 terminals
+#' @keywords internal
+#' @noRd
+menu_symbols <- function() {
+  if (cli::is_utf8_output()) {
+    list(
+      pointer = "\u276f", # <U+276F>
+      checkbox_on = "\u2611", # <U+2611>
+      checkbox_off = "\u2610", # <U+2610>
+      arrow_up = "\u2191", # <U+2191>
+      arrow_down = "\u2193" # <U+2193>
+    )
+  } else {
+    list(
+      pointer = ">",
+      checkbox_on = "[x]",
+      checkbox_off = "[ ]",
+      arrow_up = "^",
+      arrow_down = "v"
+    )
+  }
+}
+
 #' Render menu display
 #' @keywords internal
 #' @noRd
@@ -85,6 +133,11 @@ render_menu <- function(choices, cursor_pos, selected_indices, type = c("select"
                         window_offset = 1L, max_visible = NULL, allow_select_all = FALSE,
                         select_all_text = NULL) {
   type <- match.arg(type)
+
+  syms <- menu_symbols()
+  # Truncate to the terminal width so each menu entry occupies exactly one
+  # physical row; wrapped rows would break the cursor-up redraw in clear_lines()
+  width <- cli::console_width()
 
   n_choices <- length(choices)
   effective_length <- if (allow_select_all) n_choices + 1L else n_choices
@@ -102,22 +155,26 @@ render_menu <- function(choices, cursor_pos, selected_indices, type = c("select"
   # Track lines for clearing later
   lines <- character(0)
 
+  emit_line <- function(line) {
+    line <- cli::ansi_strtrim(line, width)
+    cat(line, "\n", sep = "")
+    line
+  }
+
   # Show indicator if there are items above
   items_above <- visible_start - 1L
   if (items_above > 0) {
-    indicator <- cli::col_silver(sprintf("\u2191 %d more above", items_above))
-    cat(indicator, "\n", sep = "")
-    lines <- c(lines, indicator)
+    indicator <- cli::col_silver(sprintf("%s %d more above", syms$arrow_up, items_above))
+    lines <- c(lines, emit_line(indicator))
   }
 
   # Render visible items
   for (pos in visible_start:visible_end) {
     is_cursor <- pos == cursor_pos
+    cursor_mark <- if (is_cursor) syms$pointer else " "
 
     # Handle special select all option at position 1
     if (allow_select_all && pos == 1L) {
-      # Render the special "Select all" / "Deselect all" option
-      cursor_mark <- if (is_cursor) "\u276f" else " " # <U+276F>
       # Special option doesn't have a checkbox, just text
       line <- sprintf("%s   %s", cursor_mark, select_all_text)
 
@@ -129,8 +186,7 @@ render_menu <- function(choices, cursor_pos, selected_indices, type = c("select"
         line <- cli::col_silver(line)
       }
 
-      cat(line, "\n", sep = "")
-      lines <- c(lines, line)
+      lines <- c(lines, emit_line(line))
     } else {
       # Render normal choice item
       # Map position to choice index (position 2 = index 1, etc.)
@@ -138,11 +194,9 @@ render_menu <- function(choices, cursor_pos, selected_indices, type = c("select"
       is_selected <- choice_index %in% selected_indices
 
       if (type == "checkbox") {
-        checkbox_mark <- if (is_selected) "\u2611" else "\u2610" # <U+2611> or <U+2610>
-        cursor_mark <- if (is_cursor) "\u276f" else " " # <U+276F>
+        checkbox_mark <- if (is_selected) syms$checkbox_on else syms$checkbox_off
         line <- sprintf("%s %s %s", cursor_mark, checkbox_mark, choices[choice_index])
       } else {
-        cursor_mark <- if (is_cursor) "\u276f" else " " # <U+276F>
         line <- sprintf("%s %s", cursor_mark, choices[choice_index])
       }
 
@@ -151,57 +205,41 @@ render_menu <- function(choices, cursor_pos, selected_indices, type = c("select"
         line <- cli::col_cyan(line)
       }
 
-      cat(line, "\n", sep = "")
-      lines <- c(lines, line)
+      lines <- c(lines, emit_line(line))
     }
   }
 
   # Show indicator if there are items below
   items_below <- effective_length - visible_end
   if (items_below > 0) {
-    indicator <- cli::col_silver(sprintf("\u2193 %d more below", items_below))
-    cat(indicator, "\n", sep = "")
-    lines <- c(lines, indicator)
+    indicator <- cli::col_silver(sprintf("%s %d more below", syms$arrow_down, items_below))
+    lines <- c(lines, emit_line(indicator))
   }
 
   return(lines)
 }
 
 #' Get single keypress from user
+#'
+#' keypress::keypress() returns special keys as named strings ("up",
+#' "down", "enter", "escape", ...) on every platform; regular keys come
+#' back as the character itself (space is " ").
 #' @keywords internal
 #' @importFrom keypress keypress
 #' @noRd
 get_keypress <- function() {
   key <- keypress::keypress()
 
-  if (key == "up") {
+  if (key %in% c("up", "k")) {
     return("up")
   }
-  if (key == "down") {
+  if (key %in% c("down", "j")) {
     return("down")
-  }
-  if (key == "left") {
-    return("left")
-  }
-  if (key == "right") {
-    return("right")
-  }
-  if (key == "\r" || key == "\n") {
-    return("enter")
   }
   if (key == " ") {
     return("space")
   }
-  if (key == "\033" || key == "\x1b") {
-    return("esc")
-  }
-  if (key == "k") {
-    return("up")
-  }
-  if (key == "j") {
-    return("down")
-  }
-  if (tolower(key) == "q") {
+  if (key == "escape" || tolower(key) == "q") {
     return("esc")
   }
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A lightweight, standalone module for creating interactive command-line menus in 
 - **Select all** - Optional toggle to select/deselect all items at once
 - **Pre-selection support** - Start with items already selected
 - **Return flexibility** - Return values or indices
-- **Minimal dependencies** - Only requires the `cli` package
+- **Minimal dependencies** - Only requires the `cli` and `keypress` packages
 
 ## Usage
 
@@ -93,11 +93,11 @@ choices <- checkbox(c("Item 1", "Item 2", "Item 3"))
 | Enter | Confirm selection |
 | Esc / q | Cancel (returns NULL) |
 
-On terminals that don't support single-key input (e.g. RStudio or RGui on Windows), `climenu` falls back to a numbered-prompt mode — type the number of your choice (or comma-separated numbers for checkboxes) and press Enter.
+On terminals that don't support single-key input or ANSI escape sequences (e.g. RStudio or RGui on Windows), `climenu` falls back to a numbered-prompt mode — type the number of your choice (or comma-separated numbers for checkboxes) and press Enter. On non-UTF-8 terminals, ASCII symbols are used instead of Unicode glyphs.
 
 ## API Reference
 
-### `menu(choices, prompt, type, selected, return_index)`
+### `menu(choices, prompt, type, selected, return_index, max_visible, allow_select_all)`
 
 Main entry point for creating menus.
 
@@ -108,6 +108,8 @@ Main entry point for creating menus.
 - `type` - "select" for single, "checkbox" for multiple (default: "select")
 - `selected` - Pre-selected items (indices or values)
 - `return_index` - Return indices instead of values (default: FALSE)
+- `max_visible` - Maximum items to display at once (default: 10). Set to NULL to show all.
+- `allow_select_all` - Add a "Select all" / "Deselect all" toggle at the top; checkbox type only (default: FALSE).
 
 **Returns:** Selected value(s) or NULL if cancelled
 
@@ -161,7 +163,7 @@ make all           # Run all quality checks
 
 ## Design Philosophy
 
-1. **Lightweight** - Minimal dependencies (only `cli`)
+1. **Lightweight** - Minimal dependencies (only `cli` and `keypress`)
 2. **Intuitive** - Familiar keyboard controls from other CLI tools
 3. **Flexible** - Works as a standalone package or integrated into other packages
 4. **Robust** - Graceful fallback for non-interactive environments

--- a/man/menu.Rd
+++ b/man/menu.Rd
@@ -9,7 +9,9 @@ menu(
   prompt = "Select an item:",
   type = c("select", "checkbox"),
   selected = NULL,
-  return_index = FALSE
+  return_index = FALSE,
+  max_visible = 10L,
+  allow_select_all = FALSE
 )
 }
 \arguments{
@@ -22,6 +24,13 @@ menu(
 \item{selected}{Pre-selected items (indices or values)}
 
 \item{return_index}{Return indices instead of values (default: FALSE)}
+
+\item{max_visible}{Maximum number of items to display at once (default: 10).
+Set to NULL to show all items.}
+
+\item{allow_select_all}{If \code{TRUE}, adds a "Select all" / "Deselect all"
+option at the top of the menu. Only used when \code{type = "checkbox"}
+(default: FALSE).}
 }
 \value{
 Selected item(s) as character vector or indices, or NULL if cancelled

--- a/tests/testthat/test-climenu.R
+++ b/tests/testthat/test-climenu.R
@@ -68,6 +68,59 @@ test_that("select returns NULL in non-interactive mode", {
   expect_equal(result, "Option 1")
 })
 
+test_that("select honors preselected default in non-interactive mode", {
+  choices <- c("Option 1", "Option 2", "Option 3")
+
+  expect_warning(
+    result <- climenu::select(choices, selected = 2),
+    "Not running in interactive mode"
+  )
+  expect_equal(result, "Option 2")
+
+  expect_warning(
+    result <- climenu::select(choices, selected = "Option 3", return_index = TRUE),
+    "Not running in interactive mode"
+  )
+  expect_equal(result, 3L)
+})
+
+test_that("max_visible is validated", {
+  choices <- c("A", "B", "C")
+
+  expect_error(climenu::select(choices, max_visible = 0), "max_visible")
+  expect_error(climenu::select(choices, max_visible = -1), "max_visible")
+  expect_error(climenu::checkbox(choices, max_visible = NA), "max_visible")
+  expect_error(climenu::checkbox(choices, max_visible = c(1, 2)), "max_visible")
+
+  # NULL is allowed (show all items)
+  expect_warning(
+    result <- climenu::select(choices, max_visible = NULL),
+    "Not running in interactive mode"
+  )
+  expect_equal(result, "A")
+})
+
+test_that("menu forwards max_visible and allow_select_all", {
+  choices <- c("A", "B", "C")
+
+  expect_error(climenu::menu(choices, max_visible = 0), "max_visible")
+  expect_error(
+    climenu::menu(choices, type = "checkbox", allow_select_all = "yes"),
+    "allow_select_all"
+  )
+
+  expect_warning(
+    result <- climenu::menu(
+      choices,
+      type = "checkbox",
+      selected = c(1, 3),
+      allow_select_all = TRUE
+    ),
+    "Not running in interactive mode"
+  )
+  expect_equal(result, c("A", "C"))
+})
+
 test_that("checkbox returns NULL in non-interactive mode", {
   choices <- c("Option 1", "Option 2", "Option 3")
 
@@ -113,6 +166,42 @@ test_that("render_menu creates correct output", {
 
   expect_length(lines, 3)
   expect_length(output, 3)
+})
+
+test_that("render_menu falls back to ASCII symbols on non-UTF-8 output", {
+  testthat::local_mocked_bindings(
+    is_utf8_output = function(...) FALSE,
+    .package = "cli"
+  )
+
+  output <- capture.output(
+    lines <- climenu:::render_menu(
+      c("A", "B"),
+      cursor_pos = 1, selected_indices = 2L, type = "checkbox"
+    )
+  )
+
+  expect_true(any(grepl("[x]", lines, fixed = TRUE)))
+  expect_true(any(grepl(">", lines, fixed = TRUE)))
+  expect_false(any(grepl("\u2611", lines, fixed = TRUE)))
+  expect_false(any(grepl("\u276f", lines, fixed = TRUE)))
+})
+
+test_that("render_menu truncates lines wider than the console", {
+  testthat::local_mocked_bindings(
+    console_width = function(...) 10L,
+    .package = "cli"
+  )
+
+  long_choice <- paste(rep("x", 50), collapse = "")
+  output <- capture.output(
+    lines <- climenu:::render_menu(
+      c(long_choice),
+      cursor_pos = 1, selected_indices = NULL, type = "select"
+    )
+  )
+
+  expect_true(all(cli::ansi_nchar(lines) <= 10))
 })
 
 test_that("checkbox handles empty selection", {

--- a/tests/testthat/test-fallback.R
+++ b/tests/testthat/test-fallback.R
@@ -22,6 +22,43 @@ test_that("keypress_supported returns TRUE when has_keypress_support is TRUE", {
   expect_true(climenu:::keypress_supported())
 })
 
+test_that("ansi_supported reflects cli color detection", {
+  testthat::local_mocked_bindings(
+    num_ansi_colors = function(...) 1L,
+    .package = "cli"
+  )
+  expect_false(climenu:::ansi_supported())
+
+  testthat::local_mocked_bindings(
+    num_ansi_colors = function(...) 256L,
+    .package = "cli"
+  )
+  expect_true(climenu:::ansi_supported())
+})
+
+test_that("get_keypress maps keypress return values to menu actions", {
+  get_mapped_key <- function(raw) {
+    testthat::with_mocked_bindings(
+      climenu:::get_keypress(),
+      keypress = function(...) raw,
+      .package = "keypress"
+    )
+  }
+
+  # keypress::keypress() returns special keys as named strings
+  expect_equal(get_mapped_key("escape"), "esc")
+  expect_equal(get_mapped_key("enter"), "enter")
+  expect_equal(get_mapped_key("up"), "up")
+  expect_equal(get_mapped_key("down"), "down")
+  # Regular keys come back as the character itself
+  expect_equal(get_mapped_key(" "), "space")
+  expect_equal(get_mapped_key("k"), "up")
+  expect_equal(get_mapped_key("j"), "down")
+  expect_equal(get_mapped_key("q"), "esc")
+  expect_equal(get_mapped_key("Q"), "esc")
+  expect_equal(get_mapped_key("x"), "x")
+})
+
 test_that("select_fallback returns chosen value for valid number", {
   testthat::local_mocked_bindings(read_line = function(prompt = "") "2")
   choices <- c("a", "b", "c")

--- a/vignettes/climenu.Rmd
+++ b/vignettes/climenu.Rmd
@@ -407,7 +407,7 @@ Multiple selection menu. Same parameters as `menu()` (without `type`), plus:
 
 ### Arrow keys not working
 
-Single-key input requires a real terminal (e.g. macOS Terminal, iTerm2, Linux terminals, Windows Terminal, Rterm). In RStudio or RGui on Windows, `keypress::keypress()` is not supported — `climenu` detects this automatically and switches to the numbered-prompt fallback described above. Run from a supported terminal if you want live arrow-key navigation.
+Live menus require a real terminal (e.g. macOS Terminal, iTerm2, Linux terminals, Windows Terminal, Rterm) with both single-key input and ANSI escape support. In RStudio or RGui on Windows, `keypress::keypress()` is not supported, and some consoles cannot process ANSI escapes — `climenu` detects both cases automatically and switches to the numbered-prompt fallback described above. Run from a supported terminal if you want live arrow-key navigation.
 
 ### Menu doesn't display properly
 


### PR DESCRIPTION
## Summary

Cross-platform reliability pass over the interactive menu code, prompted by the fact that the package had only been exercised on macOS. One genuine bug fixed, several portability guards added, and stale docs synced.

### Bug fixes

- **Esc never cancelled live menus on any platform.** `keypress::keypress()` returns special keys as named strings (`"enter"`, `"escape"`, ...) on every OS — verified against keypress 1.3.1 sources and docs. `get_keypress()` was checking for raw `"\r"`/`"\033"` control characters that never arrive, so `"escape"` fell through unmapped while the menu loops compare against `"esc"`. Enter only worked by coincidence (the unmatched `"enter"` string passed through unchanged). Now mapped explicitly, with the dead branches removed and a regression test over all key mappings.
- **Non-interactive `select()` ignored the `selected` default**, always returning the first choice — inconsistent with `checkbox()` and with the numbered fallback, both of which honor the default.
- **`max_visible` was unvalidated**: `max_visible = 0` rendered `choices[0]` via a descending `1:0` range and desynced the redraw line count. Now rejected up front.

### Portability guards

- **ANSI capability gate**: live menus now also require `cli::num_ansi_colors() > 1`. Keypress support does not imply VT processing (legacy Windows conhost, `TERM=dumb`, some CI TTYs) — without the gate those environments print literal `←[2K` garbage. They now get the existing numbered-prompt fallback.
- **ASCII symbol fallback**: the hardcoded `❯ ☑ ☐ ↑ ↓` glyphs degrade to `> [x] [ ] ^ v` on non-UTF-8 terminals (`cli::is_utf8_output()`), e.g. Windows with R < 4.2 or `LANG=C` servers.
- **Width truncation**: rendered lines are trimmed to `cli::console_width()` (ANSI-aware) so choices wider than the terminal can't wrap onto extra rows and corrupt the cursor-up redraw.

### API / docs

- `menu()` now forwards `max_visible` and `allow_select_all` to the underlying implementations.
- README/CLAUDE.md/AGENTS.md still called `keypress` optional (hard Import since b18c331); synced, removed the deleted `R/zzz.R` reference, and dropped the `LazyData` field that produced an R CMD check NOTE.

## Testing

- `make test`: 120 pass (was 89), `make lint`: clean, `make check`: 0 errors / 0 warnings (only the pre-existing `.git`-directory NOTE from checking inside a worktree)
- Drove the live menu end-to-end in a real PTY (`script` + keystroke injection): `j`+Enter selects the second item, **Esc cancels and returns NULL** (broken before this change), Space toggles checkboxes, and an environment without `TERM` correctly routes to the numbered-prompt fallback via the new ANSI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)