### PR TITLE
build: bump version 0.1.7 -> 0.1.8 and add NEWS.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: climenu
 Title: Interactive Command-Line Menus
-Version: 0.1.7
+Version: 0.1.8
 Authors@R:
     person("Petr", "Čala", , "61505008@fsv.cuni.cz", role = c("aut", "cre"))
 Author: Petr Čala [aut, cre]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,11 @@
+# climenu 0.1.8
+
+* Esc now cancels live menus on every platform. Previously the key was ignored and only `q` cancelled.
+* Menus fall back to numbered-prompt mode on terminals without ANSI escape support, so single-key-capable but non-VT consoles (for example legacy Windows consoles) no longer render a broken live menu.
+* Menu symbols degrade to ASCII on non-UTF-8 terminals, and rendered lines are truncated to the console width so wrapped rows cannot corrupt the redraw.
+* `select()` now honors the preselected default in non-interactive sessions.
+* `menu()` validates `max_visible` and forwards `max_visible` and `allow_select_all` to the underlying menu.
+
+# climenu 0.1.7
+
+* Initial CRAN release.


### PR DESCRIPTION
## What

Prepares the next CRAN release by bumping the package version and adding a changelog.

- **DESCRIPTION**: `Version: 0.1.7` -> `0.1.8`
- **NEWS.md** (new file): documents the 0.1.8 changes and marks 0.1.7 as the initial CRAN release

## Why

CRAN already has 0.1.7 (published 2026-04-15). The cross-platform reliability fixes from #2 landed on master afterward but never shipped: the `Submit to CRAN` workflow correctly skips resubmission while DESCRIPTION still matches the published version (the `--as-cran` check emits `Insufficient package version (submitted: 0.1.7, existing: 0.1.7)`, which flips the check status to failure and gates the submit job off).

Bumping to 0.1.8 is what unblocks the next submission.

## Release flow after merge

Merging to `master` triggers [.github/workflows/submit-cran.yaml](.github/workflows/submit-cran.yaml): it runs `R CMD check --as-cran`, and with the fresh version the check should pass and the submit job will call `devtools:::upload_cran()`. The maintainer must then confirm the submission from the CRAN email before it goes live. Opening this PR does not submit anything (the submit workflow only runs on push to `master`).

## Changelog (0.1.8)

- Esc now cancels live menus on every platform (previously only `q` worked)
- Fall back to numbered-prompt mode on terminals without ANSI escape support
- ASCII menu symbols on non-UTF-8 terminals; rendered lines truncated to console width
- `select()` honors the preselected default in non-interactive sessions
- `menu()` validates `max_visible` and forwards `max_visible` / `allow_select_all`

## Testing

`devtools::test()` -> 120 passed, 0 failures, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)